### PR TITLE
Tony/fixes

### DIFF
--- a/src/components/SharedDishTile.js
+++ b/src/components/SharedDishTile.js
@@ -63,7 +63,10 @@ export default function (props) {
     <DishTile className={props.className} onClick={props.onClick}>
       <TileTitle>
         <Name>{props.dish.name}</Name>
-        <TitleTrailing>{'$' + props.dish.price}</TitleTrailing>
+        {
+          props.dish.price ?
+          <TitleTrailing>{'$' + props.dish.price}</TitleTrailing> : <></>
+        }
       </TileTitle>
       {props.dish.description ? (
         <TileSubtitle>

--- a/src/narrow-screen/components/FilterSlideUpPanel.js
+++ b/src/narrow-screen/components/FilterSlideUpPanel.js
@@ -46,6 +46,10 @@ const ClearButton = styled(Button)`
   z-index: 25;
 `;
 
+const StyledExpansionArrow = styled(ExpansionArrow)`
+  margin: 0 25px;
+`;
+
 function SlideUpPanelHeader(props) {
   return (
     <PanelHeader>
@@ -62,7 +66,7 @@ function SlideUpPanelHeader(props) {
       </PanelHeaderElement>
       <Spacer onClick={props.onExpansionChanged}/>
       <PanelHeaderElement>
-        <ClearButton id='clear-btn'
+        <ClearButton
           variant='secondary'
           disabled={props.selected.size === 0}
           onClick={props.onClearFilter}
@@ -71,7 +75,7 @@ function SlideUpPanelHeader(props) {
         </ClearButton>
       </PanelHeaderElement>
       <PanelHeaderElement>
-        <ExpansionArrow
+        <StyledExpansionArrow
           onClick={props.onExpansionChanged}
           pointingUp={!props.expanded ? 1 : 0}
         />

--- a/src/narrow-screen/screens/RestaurantScreen.js
+++ b/src/narrow-screen/screens/RestaurantScreen.js
@@ -87,7 +87,7 @@ export default class extends React.Component {
           </AllMenusButton>
           <RestaurantLogo href="https://www.bacariwadams.com/">
             <ReactSVG
-              wrapper="span"
+              wrapper="div"
               src={`${process.env.REACT_APP_API_BASE_URL}/api/assets/restaurant_logos/bacari.svg`}
             />
           </RestaurantLogo>

--- a/src/narrow-screen/screens/RestaurantScreen.js
+++ b/src/narrow-screen/screens/RestaurantScreen.js
@@ -99,7 +99,7 @@ export default class extends React.Component {
             restaurantName={this.props.restaurantId}
             menu={this.props.dishesByMenu[this.props.selectedMenuIndex]}
           />
-        ) : this.state.error ? (
+        ) : this.props.error ? (
           <PageError>
             There was an error loading this page. Please try reloading the page
             or contact the Nomi team by filling out a form at dinewithnomi.com

--- a/src/screens/RestaurantMenuScreen.js
+++ b/src/screens/RestaurantMenuScreen.js
@@ -30,6 +30,7 @@ class RestaurantMenuScreen extends React.Component {
           .then(dishesByMenu => this.setState({ dishesByMenu: dishesByMenu }));
       })
       .catch(err => {
+        console.log(err);
         this.setState({ error: err });
       });
   }

--- a/src/wide-screen/components/AllergenFiltersSidePanel.js
+++ b/src/wide-screen/components/AllergenFiltersSidePanel.js
@@ -89,7 +89,7 @@ export default class AllergenFiltersSidePanel extends React.Component {
         <this.props.StyledHeader
           onClick={this.onExpansionChanged.bind(this)}
         >
-          <div class='text'>
+          <div className={'text'}>
             Allergen Filters
           </div>
           <div style={{

--- a/src/wide-screen/components/HotScrollSidePanel.js
+++ b/src/wide-screen/components/HotScrollSidePanel.js
@@ -36,7 +36,7 @@ export default class extends React.Component {
         <this.props.StyledHeader
           onClick={this.onExpansionChanged.bind(this)}
         >
-          <div class="text">
+          <div className="text">
             Menu Sections
           </div>
             <this.props.StyledExpandArrow

--- a/src/wide-screen/components/MenuTabNav.js
+++ b/src/wide-screen/components/MenuTabNav.js
@@ -2,58 +2,39 @@ import React from 'react';
 import styled from 'styled-components';
 import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
 
-const MenuTabs = styled(Tabs)`
-  width: 100%;
-  margin-left: 13%;
-`;
-
-const MenuTab = styled(Tab)`
-  height: 30px;
+const MenuTab = styled.div`
   display: inline-block;
-  margin: 20px 15px 0 15px;
-  padding-bottom: 10px;
+  margin: 18px 15px 0 15px;
   color: rgba(0, 0, 0, 0.25);
 
   &.is-selected {
     color: black;
-    padding-bottom: 6px;
+    padding-bottom: 10px;
     border-bottom-left-radius: 4px;
     border-bottom-right-radius: 4px;
     border-bottom: solid 4px #5383EC;
   }
 `;
 
-// TODO: Restrict the width of tab bar
-// Maybe we also need to re-align the icons in the top bar
-const MenuTabList = styled(TabList)`
-  list-style-type: none;
-  padding: 0 5px;
-  overflow: auto;
+const MenuTabList = styled.div`
+  max-width: 100%;
+  overflow: scroll;
   white-space: nowrap;
-  position: sticky;
-  background-color: white;
-  z-index: 10;
 `;
 
 export default function(props) {
   return (
-    <MenuTabs
-      selectedIndex={props.selectedMenuIndex}
-      forceRenderTabPanel={true}
-      onSelect={props.onSelectMenu.bind(this)}
-    >
-      <MenuTabList>
-        {
-          props.menus.map((menu, i) =>
-            <MenuTab
-              key={menu.id}
-              className={props.selectedMenuIndex === i ? 'is-selected': ''}
-              onClick={() => props.onSelectMenu(i)}
-            >
-              {menu.name}
-            </MenuTab>)
-        }
-      </MenuTabList>
-    </MenuTabs>
+    <MenuTabList>
+      {
+        props.menus.map((menu, i) =>
+          <MenuTab
+            key={menu.id}
+            className={props.selectedMenuIndex === i ? 'is-selected': ''}
+            onClick={() => props.onSelectMenu(i)}
+          >
+            {menu.name}
+          </MenuTab>)
+      }
+    </MenuTabList>
   )
 };

--- a/src/wide-screen/screens/MenuScreen.js
+++ b/src/wide-screen/screens/MenuScreen.js
@@ -9,10 +9,8 @@ import QRCodeSidePanel from "../components/QRCodeSidePanel";
 import { ReactComponent as NomiLogo } from "components/nomi-withword.svg";
 import styled from "styled-components";
 import BannerImage from "components/web_menu_banner.jpg";
-import QRCode from "qrcode.react";
 
 const ColumnStyle = styled.div`
-  height: 100%;
   padding: 20px 16px;
   overflow: scroll;
   &::-webkit-scrollbar {
@@ -51,7 +49,6 @@ const Panel = styled.div`
 
   flex: none;
   order: 0;
-  align-self: center;
   margin: 15px 15px;
 `;
 
@@ -202,7 +199,7 @@ const NomiBottomLogoImage = styled.a`
 
 function MainContent(props) {
   return (
-    <MainContentWrapper id="mainContent">
+    <MainContentWrapper>
       <Banner>
         <RestaurantName>{props.restaruantName}</RestaurantName>
       </Banner>
@@ -231,8 +228,6 @@ function MainContent(props) {
 
 const MenuScreen = styled.div`
   position: relative;
-  align-items: center;
-  justify-content: center;
   display: flex;
   flex-flow: row;
   flex: 1 1 auto;

--- a/src/wide-screen/screens/RestaurantScreen.js
+++ b/src/wide-screen/screens/RestaurantScreen.js
@@ -127,7 +127,7 @@ export default class extends React.Component{
           />
           :
           (
-            this.state.error ?
+            this.props.error ?
             <PageError>There was an error loading this page. Please try reloading the page or contact the Nomi team by filling out a form at dinewithnomi.com</PageError> :
             <Loading>Restaurant Menu Loading...</Loading>
           )

--- a/src/wide-screen/screens/RestaurantScreen.js
+++ b/src/wide-screen/screens/RestaurantScreen.js
@@ -3,8 +3,6 @@ import MenuScreen from './MenuScreen';
 import RestaurantLogo from 'components/bacari-logo.png';
 import { ReactComponent as NomiTopBottomLogo } from 'components/nomi-topbottom.svg';
 import styled from 'styled-components';
-import MenuListNav from 'components/MenuListNav';
-import { Button } from 'react-bootstrap';
 import MenuTabNav from '../components/MenuTabNav';
 
 const RestaurantScreen = styled.div`
@@ -27,32 +25,15 @@ const Header = styled.div`
   box-shadow: 0px 8px 20px rgba(0, 20, 63, 0.05);
 `;
 
-const AllMenusButton = styled(Button)`
-  position: relative;
-  margin-left: 20px;
-  z-index: 20;
-  display: block;
-  font-weight: bold;
-  color: #628DEB;
-
-  text-decoration: none;
-  &:hover, &:focus {
-    text-decoration: none;
-  }
-`;
-
 const NomiLogo = styled(NomiTopBottomLogo)`
   position: relative;
   display: inline-block;
-  margin-left: 2%;
-  margin-right: 2%;
 `;
 
 const RestaurantImgLogo = styled.img`
   height: 28px;
   width: 84px;
-  margin-left: 10%;
-  margin-right: 10%;
+  display: inline-block;
 `;
 
 const FilterToggleSwitch = styled.div`
@@ -89,6 +70,10 @@ const Loading = styled.div`
   font-weight: bold;
 `;
 
+const HeaderColumns = styled.div`
+  text-align: center;
+`;
+
 export default class extends React.Component{
 
   state = {
@@ -106,19 +91,21 @@ export default class extends React.Component{
     return (
       <RestaurantScreen>
         <Header>
-          <NomiLogo
-            width='70px'
-            height='28px'
-          />
-          <RestaurantImgLogo src={RestaurantLogo} />
-          <MenuTabNav
-            {...this.props}
-          />
+          <HeaderColumns style={{ width: '20%' }}>
+            <RestaurantImgLogo src={RestaurantLogo} />
+          </HeaderColumns>
+          <HeaderColumns style={{ width: '60%' }}>
+            <MenuTabNav
+              {...this.props}
+            />
+          </HeaderColumns>
+          <HeaderColumns style={{ width: '20%' }}>
+            <NomiLogo
+              width='70px'
+              height='28px'
+            />
+          </HeaderColumns>
         </Header>
-        <MenuListNav
-          open={this.state.hamburgerOpen}
-          {...this.props}
-        />
         {this.props.dishesByMenu.length > 0 ?
           <MenuScreen
             onClick={() => this.setState({ hamburgerOpen: false })}


### PR DESCRIPTION
- MenuScreen this.state -> this.props to show error message
- Remove dollar sign when a dish has no price
- Fixed scrolling and center-aligned columns in wide-screen/.../MenuScreen
- Expansion arrow margin in FilterSlideUpPanel (was set to zero by https://github.com/Nomi-Technologies/web-menu/pull/27)
- ReactSVG does not work in Safari when rendered in spans, changed to div
- Minor cleanups

New:
- Reworked wide-screen's tab bar list