### PR TITLE
fixing image display for dishes

### DIFF
--- a/src/components/Banner.js
+++ b/src/components/Banner.js
@@ -32,7 +32,7 @@ export default function(props) {
   return (
     <Banner className={props.className} src={ props.src }>
       {props.children}
-      <BlackLayer/>
+      {props.removeOverlay ? null : <BlackLayer/>}
     </Banner>
   )
 }

--- a/src/components/DishInfoModal.js
+++ b/src/components/DishInfoModal.js
@@ -374,7 +374,7 @@ export default function(props) {
     >
       {
         dishImage ?
-        <StyledBanner src={ dishImage } />
+        <StyledBanner src={ dishImage } removeOverlay />
         : ""
       }
       <ModalContainer style={modalStyle}>


### PR DESCRIPTION
**Ticket:** [Fixing display of image](https://www.notion.so/dinewithnomi/BUG-Hide-dish-image-if-no-image-exists-rework-border-radius-styling-14b3498dce074858a9dcd866a8d73966)

Note: Wasn't able to reproduce the original issue from the ticket (black box appearing when there's no image), however, there were some other styling issues with the image that I have fixed.

**Changes Made:**
- adding styling to dish image so that it is styled correctly in web and mobile versions
- remove top border-radius of modal when an image is attached to the top
- removing transparent black overlay from dish image
- changing modal size to become full screen later

